### PR TITLE
 Ignore renderer specific assets if the path is empty

### DIFF
--- a/azure_batch_maya/modules/arnold_renderer.py
+++ b/azure_batch_maya/modules/arnold_renderer.py
@@ -126,7 +126,9 @@ class ArnoldRenderAssets(AzureBatchRenderAssets):
             nodes = cmds.ls(type=node_type)
             for node in nodes:
                 for attr in attributes:
-                    collected.append(cmds.getAttr(node + '.' + attr))
+                    path = cmds.getAttr(node + '.' + attr)
+                    if path:
+                        collected.append(path)
         for path in collected:
             self.assets.append(self.check_path(path))
         return self.assets

--- a/azure_batch_maya/modules/vray_renderer.py
+++ b/azure_batch_maya/modules/vray_renderer.py
@@ -130,8 +130,9 @@ class VrayRenderAssets(AzureBatchRenderAssets):
             nodes = cmds.ls(type=node_type)
             for node in nodes:
                 for attr in attributes:
-                    collected.append(cmds.getAttr(node + "." + attr))
-
+                    path = cmds.getAttr(node + '.' + attr)
+                    if path:
+                        collected.append(path)
         for path in collected:
             self.assets.append(self.check_path(path))
         return self.assets


### PR DESCRIPTION
Prior to this change an empty asset path leads to the inclusion of an asset representing the project directory, this has been reported to prevent other assets being uploaded when included in the job asset list