### PR TITLE
Asset path redirection updates

### DIFF
--- a/azure_batch_maya/modules/default.py
+++ b/azure_batch_maya/modules/default.py
@@ -168,6 +168,9 @@ class AzureBatchRenderJob(object):
         if not output:
             return None
         cmds.textFieldButtonGrp(k, edit=True, text=str(output[0]))
+    
+    def final_setup(self, job_data, asset_data):
+        pass
 
 
 class AzureBatchRenderAssets(object):
@@ -177,3 +180,6 @@ class AzureBatchRenderAssets(object):
 
     def renderer_assets(self):
         return self.assets
+
+    def setup_script(self, script_handle, pathmap, searchpaths):
+        pass

--- a/azure_batch_maya/modules/vray_renderer.py
+++ b/azure_batch_maya/modules/vray_renderer.py
@@ -87,6 +87,10 @@ class VrayRenderJob(AzureBatchRenderJob):
         params['frameStep'] = cmds.intField(self.step, query=True, value=True)
         params['renderer'] = self._renderer
         return params
+    
+    def final_setup(self, job_data, asset_data):
+        job_data['commonEnvironmentSettings'].append(
+            {'name': 'VRAY_ASSETS_PATH', 'value': asset_data['search_paths']})
 
 
 class VrayRenderAssets(AzureBatchRenderAssets):

--- a/azure_batch_maya/scripts/tools/generate_thumbnails.py
+++ b/azure_batch_maya/scripts/tools/generate_thumbnails.py
@@ -11,6 +11,11 @@ SUPPORTED_FORMATS =  { ".png", ".bmp", ".jpg", ".tga", ".exr", ".jpeg" }
 
 if __name__ == '__main__':
     try:
+        thumb_dir = os.path.join(cwd, 'thumbs')
+        if not os.path.isdir(thumb_dir):
+            print("Creating directory for thumbnail output.")
+            os.makedirs(thumb_dir)
+        
         render_exit_code = int(sys.argv[1])
         print("Render process exited with code: {}".format(render_exit_code))
         cwd = os.getcwd()
@@ -34,11 +39,6 @@ if __name__ == '__main__':
             if beauty_pass:
                 input_file = beauty_pass[0]
         print("Using output '{}' for thumbnail generation.".format(input_file))
-
-        thumb_dir = os.path.join(cwd, 'thumbs')
-        if not os.path.isdir(thumb_dir):
-            print("Creating directory for thumbnail output.")
-            os.makedirs(thumb_dir)
 
         task_id = os.environ['AZ_BATCH_TASK_ID']
         output_file = os.path.join(thumb_dir, task_id + '_thumb.png')

--- a/azure_batch_maya/scripts/tools/generate_thumbnails.py
+++ b/azure_batch_maya/scripts/tools/generate_thumbnails.py
@@ -11,6 +11,7 @@ SUPPORTED_FORMATS =  { ".png", ".bmp", ".jpg", ".tga", ".exr", ".jpeg" }
 
 if __name__ == '__main__':
     try:
+        cwd = os.getcwd()
         thumb_dir = os.path.join(cwd, 'thumbs')
         if not os.path.isdir(thumb_dir):
             print("Creating directory for thumbnail output.")
@@ -18,7 +19,7 @@ if __name__ == '__main__':
         
         render_exit_code = int(sys.argv[1])
         print("Render process exited with code: {}".format(render_exit_code))
-        cwd = os.getcwd()
+        
         job_outputs = os.path.join(cwd, 'images')
         if not os.path.isdir(job_outputs):
             raise Exception("Unable to locate output directory: {}".format(job_outputs))

--- a/azure_batch_maya/templates/vray-basic-linux.json
+++ b/azure_batch_maya/templates/vray-basic-linux.json
@@ -113,7 +113,7 @@
           "elevationLevel": "admin"
         }
       },
-      "commandLine": "sudo mkdir -m a=rwx -p \"/X\";sudo mount --rbind $AZ_BATCH_JOB_PREP_WORKING_DIR/assets /X;Render -renderer [parameters('renderer')] -proj \"$AZ_BATCH_JOB_PREP_WORKING_DIR\" -verb -rd \"$AZ_BATCH_TASK_WORKING_DIR/images\" -s {0} -e {0} \"[parameters('sceneFile')]\";err=$?;python /mnt/resource/batch/tasks/workitems/[parameters('outputs')]/job-1/jobpreparation/wd/thumbnail.py $err;sudo umount \"/X\";exit $err",
+      "commandLine": "sudo mkdir -m a=rwx -p \"/X\";sudo mount --rbind $AZ_BATCH_JOB_PREP_WORKING_DIR/assets /X;Render -renderer [parameters('renderer')] -proj \"$AZ_BATCH_JOB_PREP_WORKING_DIR\" -verb -preRender renderPrep -rd \"$AZ_BATCH_TASK_WORKING_DIR/images\" -s {0} -e {0} \"[parameters('sceneFile')]\";err=$?;python /mnt/resource/batch/tasks/workitems/[parameters('outputs')]/job-1/jobpreparation/wd/thumbnail.py $err;sudo umount \"/X\";exit $err",
       "environmentSettings": [
         {
           "name": "MAYA_SCRIPT_PATH",

--- a/azure_batch_maya/templates/vray-basic-windows.json
+++ b/azure_batch_maya/templates/vray-basic-windows.json
@@ -107,7 +107,7 @@
     ],
     "repeatTask": {
       "displayName": "Frame {0}",
-      "commandLine": "subst X: %AZ_BATCH_JOB_PREP_WORKING_DIR%\\assets & render -renderer [parameters('renderer')] -proj \"%AZ_BATCH_JOB_PREP_WORKING_DIR%\" -verb -rd \"%AZ_BATCH_TASK_WORKING_DIR%\\images\" -s {0} -e {0} \"[parameters('sceneFile')]\" & call mayapy %AZ_BATCH_JOB_PREP_WORKING_DIR%\\thumbnail.py %^errorlevel%",
+      "commandLine": "subst X: %AZ_BATCH_JOB_PREP_WORKING_DIR%\\assets & render -renderer [parameters('renderer')] -proj \"%AZ_BATCH_JOB_PREP_WORKING_DIR%\" -verb -preRender renderPrep -rd \"%AZ_BATCH_TASK_WORKING_DIR%\\images\" -s {0} -e {0} \"[parameters('sceneFile')]\" & call mayapy %AZ_BATCH_JOB_PREP_WORKING_DIR%\\thumbnail.py %^errorlevel%",
       "environmentSettings": [
         {
           "name": "MAYA_SCRIPT_PATH",


### PR DESCRIPTION
- Better renderer-specific control on both asset pre-render scripting and job settings
- Fixed bug in thumbnail script where if the render fails and there's no outputs, no "thumbs" directory gets created which causes an output file upload error.
- Better Vray file redirection by adding env variable search path list. Also added back use of the pre-render MEL as the errors in this seem to be resolved in the latest releases.
- Better Arnold file redirection by stripping full path from aiImage node paths in pre-render MEL.